### PR TITLE
Category Views

### DIFF
--- a/rareapi/views/category.py
+++ b/rareapi/views/category.py
@@ -28,6 +28,7 @@ class CategoryView(ViewSet):
             Response -- JSON serialized list of category types
         """
         category = Category.objects.all()
+        category = Category.objects.order_by('label')
         serializer = CategorySerializer(category, many=True)
         return Response(serializer.data) 
     


### PR DESCRIPTION
added line in category def list to sort by label and can be viewed server side. Can also see sorted categories via Postman

Fixes issue #11 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Can open Postman to view sorted categories & can click "Category Management" in webpage navbar to view client side categories sorted

- [X] Test A
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings